### PR TITLE
For #131: implementes Ast class

### DIFF
--- a/aibolit/patterns/assert_in_code/assert_in_code.py
+++ b/aibolit/patterns/assert_in_code/assert_in_code.py
@@ -1,6 +1,7 @@
 import javalang.ast
 import javalang.parse
 import javalang.tree
+from aibolit.utils.ast import Ast
 
 
 _TEST_CLASS_SUFFIX = 'Test'
@@ -8,19 +9,9 @@ _TEST_CLASS_SUFFIX = 'Test'
 
 class AssertInCode(object):
     def value(self, filename: str):
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
 
         return self.__traverse_node(tree)
-
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-
-        with open(filename) as file:
-            return javalang.parse.parse(file.read())
 
     def __traverse_node(self, tree: javalang.ast.Node):
         lines = list()

--- a/aibolit/patterns/assert_in_code/assert_in_code.py
+++ b/aibolit/patterns/assert_in_code/assert_in_code.py
@@ -1,7 +1,7 @@
 import javalang.ast
 import javalang.parse
 import javalang.tree
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 
 _TEST_CLASS_SUFFIX = 'Test'
@@ -9,7 +9,7 @@ _TEST_CLASS_SUFFIX = 'Test'
 
 class AssertInCode(object):
     def value(self, filename: str):
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
 
         return self.__traverse_node(tree)
 

--- a/aibolit/patterns/classic_setter/classic_setter.py
+++ b/aibolit/patterns/classic_setter/classic_setter.py
@@ -1,4 +1,5 @@
 import javalang
+from aibolit.utils.ast import Ast
 
 
 class ClassicSetter:
@@ -6,19 +7,9 @@ class ClassicSetter:
     def __init__(self):
         pass
 
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            tree = javalang.parse.parse(file.read())
-        return tree
-
     def value(self, filename: str):
         lst = []
-        tree = self.__file_to_ast(filename).filter(javalang.tree.MethodDeclaration)
+        tree = Ast(filename).value().filter(javalang.tree.MethodDeclaration)
         for path, node in tree:
             if (node.return_type is None) and ('set' in node.name[:3]):
                 if (isinstance(node.body, list)) and len(node.body) < 2:

--- a/aibolit/patterns/classic_setter/classic_setter.py
+++ b/aibolit/patterns/classic_setter/classic_setter.py
@@ -1,5 +1,5 @@
 import javalang
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 
 class ClassicSetter:
@@ -9,7 +9,7 @@ class ClassicSetter:
 
     def value(self, filename: str):
         lst = []
-        tree = Ast(filename).value().filter(javalang.tree.MethodDeclaration)
+        tree = AST(filename).value().filter(javalang.tree.MethodDeclaration)
         for path, node in tree:
             if (node.return_type is None) and ('set' in node.name[:3]):
                 if (isinstance(node.body, list)) and len(node.body) < 2:

--- a/aibolit/patterns/empty_rethrow/empty_rethrow.py
+++ b/aibolit/patterns/empty_rethrow/empty_rethrow.py
@@ -21,24 +21,16 @@
 # SOFTWARE.
 
 import javalang
-
+from aibolit.utils.ast import Ast
 
 class EmptyRethrow:
 
     def __init__(self):
         pass
 
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            tree = javalang.parse.parse(file.read())
-
-        return tree
 
     def value(self, filename):
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
         total_code_lines = set()
         for _, method_node in tree.filter(javalang.tree.MethodDeclaration):
             for _, try_node in method_node.filter(javalang.tree.TryStatement):

--- a/aibolit/patterns/empty_rethrow/empty_rethrow.py
+++ b/aibolit/patterns/empty_rethrow/empty_rethrow.py
@@ -23,11 +23,11 @@
 import javalang
 from aibolit.utils.ast import AST
 
+
 class EmptyRethrow:
 
     def __init__(self):
         pass
-
 
     def value(self, filename):
         tree = AST(filename).value()

--- a/aibolit/patterns/empty_rethrow/empty_rethrow.py
+++ b/aibolit/patterns/empty_rethrow/empty_rethrow.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 import javalang
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 class EmptyRethrow:
 
@@ -30,7 +30,7 @@ class EmptyRethrow:
 
 
     def value(self, filename):
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
         total_code_lines = set()
         for _, method_node in tree.filter(javalang.tree.MethodDeclaration):
             for _, try_node in method_node.filter(javalang.tree.TryStatement):

--- a/aibolit/patterns/er_class/er_class.py
+++ b/aibolit/patterns/er_class/er_class.py
@@ -1,5 +1,5 @@
 import javalang
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 
 class ErClass:
@@ -22,5 +22,5 @@ class ErClass:
                    'producer',
                    'holder',
                    'interceptor')
-        tree = Ast(filename).value().filter(javalang.tree.ClassDeclaration)
+        tree = AST(filename).value().filter(javalang.tree.ClassDeclaration)
         return [node._position.line for _, node in tree if [n for n in classes if n in node.name.lower()] != []]

--- a/aibolit/patterns/er_class/er_class.py
+++ b/aibolit/patterns/er_class/er_class.py
@@ -1,20 +1,11 @@
 import javalang
+from aibolit.utils.ast import Ast
 
 
 class ErClass:
 
     def __init__(self):
         pass
-
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            tree = javalang.parse.parse(file.read())
-        return tree
 
     def value(self, filename: str):
         classes = ('manager',
@@ -31,5 +22,5 @@ class ErClass:
                    'producer',
                    'holder',
                    'interceptor')
-        tree = self.__file_to_ast(filename).filter(javalang.tree.ClassDeclaration)
+        tree = Ast(filename).value().filter(javalang.tree.ClassDeclaration)
         return [node._position.line for _, node in tree if [n for n in classes if n in node.name.lower()] != []]

--- a/aibolit/patterns/force_type_casting_finder/force_type_casting_finder.py
+++ b/aibolit/patterns/force_type_casting_finder/force_type_casting_finder.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 import javalang
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 
 class ForceTypeCastingFinder:
@@ -54,7 +54,7 @@ class ForceTypeCastingFinder:
 
     def value(self, filename: str):
         ''''''
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
         list_tree = self.__tree_to_list(tree)
         num_str = []
         for node in list_tree:

--- a/aibolit/patterns/force_type_casting_finder/force_type_casting_finder.py
+++ b/aibolit/patterns/force_type_casting_finder/force_type_casting_finder.py
@@ -21,15 +21,10 @@
 # SOFTWARE.
 
 import javalang
+from aibolit.utils.ast import Ast
 
 
 class ForceTypeCastingFinder:
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        '''Takes path to java class file and returns AST Tree'''
-        with open(filename, encoding='utf-8') as file:
-            tree = javalang.parse.parse(file.read())
-
-        return tree
 
     def __process_node(self, node):
         line = node.position.line if hasattr(node, 'position') and node.position is not None else None
@@ -59,7 +54,7 @@ class ForceTypeCastingFinder:
 
     def value(self, filename: str):
         ''''''
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
         list_tree = self.__tree_to_list(tree)
         num_str = []
         for node in list_tree:

--- a/aibolit/patterns/implements_multi/implements_multi.py
+++ b/aibolit/patterns/implements_multi/implements_multi.py
@@ -1,5 +1,5 @@
 import javalang
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 
 class ImplementsMultiFinder:
@@ -8,5 +8,5 @@ class ImplementsMultiFinder:
         pass
 
     def value(self, filename: str):
-        tree = Ast(filename).value().filter(javalang.tree.ClassDeclaration)
+        tree = AST(filename).value().filter(javalang.tree.ClassDeclaration)
         return [node._position.line for _, node in tree if node.implements and (len(node.implements) > 1)]

--- a/aibolit/patterns/implements_multi/implements_multi.py
+++ b/aibolit/patterns/implements_multi/implements_multi.py
@@ -1,4 +1,5 @@
 import javalang
+from aibolit.utils.ast import Ast
 
 
 class ImplementsMultiFinder:
@@ -6,16 +7,6 @@ class ImplementsMultiFinder:
     def __init__(self):
         pass
 
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            tree = javalang.parse.parse(file.read())
-        return tree
-
     def value(self, filename: str):
-        tree = self.__file_to_ast(filename).filter(javalang.tree.ClassDeclaration)
+        tree = Ast(filename).value().filter(javalang.tree.ClassDeclaration)
         return [node._position.line for _, node in tree if node.implements and (len(node.implements) > 1)]

--- a/aibolit/patterns/instanceof/instance_of.py
+++ b/aibolit/patterns/instanceof/instance_of.py
@@ -1,5 +1,5 @@
 import javalang
-
+from aibolit.utils.ast import Ast
 
 class InstanceOf:
 
@@ -24,17 +24,8 @@ class InstanceOf:
 
         return lines
 
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            res = javalang.parse.parse(file.read())
-        return res
 
     # flake8: noqa: C901
     def value(self, filename: str):
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
         return self.__traverse_node(tree)

--- a/aibolit/patterns/instanceof/instance_of.py
+++ b/aibolit/patterns/instanceof/instance_of.py
@@ -1,5 +1,5 @@
 import javalang
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 class InstanceOf:
 
@@ -27,5 +27,5 @@ class InstanceOf:
 
     # flake8: noqa: C901
     def value(self, filename: str):
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
         return self.__traverse_node(tree)

--- a/aibolit/patterns/many_primary_ctors/many_primary_ctors.py
+++ b/aibolit/patterns/many_primary_ctors/many_primary_ctors.py
@@ -23,23 +23,14 @@
 import javalang.ast
 import javalang.parse
 import javalang.tree
+from aibolit.utils.ast import Ast
 
 
 class ManyPrimaryCtors(object):
     def value(self, filename: str):
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
 
         return self.__traverse_node(tree)
-
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-
-        with open(filename) as file:
-            return javalang.parse.parse(file.read())
 
     def __traverse_node(self, tree: javalang.ast.Node):
         lines = list()

--- a/aibolit/patterns/many_primary_ctors/many_primary_ctors.py
+++ b/aibolit/patterns/many_primary_ctors/many_primary_ctors.py
@@ -23,12 +23,12 @@
 import javalang.ast
 import javalang.parse
 import javalang.tree
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 
 class ManyPrimaryCtors(object):
     def value(self, filename: str):
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
 
         return self.__traverse_node(tree)
 

--- a/aibolit/patterns/method_chaining/method_chaining.py
+++ b/aibolit/patterns/method_chaining/method_chaining.py
@@ -2,6 +2,7 @@ import javalang
 
 import uuid
 from collections import defaultdict
+from aibolit.utils.ast import Ast
 
 
 class MethodChainFind:
@@ -41,15 +42,6 @@ class MethodChainFind:
 
         return dict_with_chains
 
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            res = javalang.parse.parse(file.read())
-        return res
 
     # flake8: noqa: C901
     def value(self, filename: str):
@@ -60,7 +52,7 @@ class MethodChainFind:
         List of tuples with LineNumber and List of methods names, e.g.
         [[10, 'func1'], [10, 'fun2']], [[23, 'run'], [23, 'start']]]
         """
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
         chain_lst = defaultdict(list)
         for path, node in tree.filter(javalang.tree.StatementExpression):
             if isinstance(node.expression, javalang.tree.MethodInvocation):

--- a/aibolit/patterns/method_chaining/method_chaining.py
+++ b/aibolit/patterns/method_chaining/method_chaining.py
@@ -2,7 +2,7 @@ import javalang
 
 import uuid
 from collections import defaultdict
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 
 class MethodChainFind:
@@ -52,7 +52,7 @@ class MethodChainFind:
         List of tuples with LineNumber and List of methods names, e.g.
         [[10, 'func1'], [10, 'fun2']], [[23, 'run'], [23, 'start']]]
         """
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
         chain_lst = defaultdict(list)
         for path, node in tree.filter(javalang.tree.StatementExpression):
             if isinstance(node.expression, javalang.tree.MethodInvocation):

--- a/aibolit/patterns/multiple_try/multiple_try.py
+++ b/aibolit/patterns/multiple_try/multiple_try.py
@@ -4,6 +4,7 @@ import uuid
 from collections import defaultdict
 import hashlib
 import itertools
+from aibolit.utils.ast import Ast
 
 class MultipleTry:
 
@@ -42,15 +43,6 @@ class MultipleTry:
 
         return dict_with_chains
 
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            res = javalang.parse.parse(file.read())
-        return res
 
     # flake8: noqa: C901
     def value(self, filename: str):
@@ -62,7 +54,7 @@ class MultipleTry:
         [[10, 'func1'], [10, 'fun2']], [[23, 'run'], [23, 'start']]]
         """
 
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
         res = defaultdict(list)
         for _, method_node in tree.filter(javalang.tree.MethodDeclaration):
             for _, try_node in method_node.filter(javalang.tree.TryStatement):

--- a/aibolit/patterns/multiple_try/multiple_try.py
+++ b/aibolit/patterns/multiple_try/multiple_try.py
@@ -4,7 +4,7 @@ import uuid
 from collections import defaultdict
 import hashlib
 import itertools
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 class MultipleTry:
 
@@ -54,7 +54,7 @@ class MultipleTry:
         [[10, 'func1'], [10, 'fun2']], [[23, 'run'], [23, 'start']]]
         """
 
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
         res = defaultdict(list)
         for _, method_node in tree.filter(javalang.tree.MethodDeclaration):
             for _, try_node in method_node.filter(javalang.tree.TryStatement):

--- a/aibolit/patterns/nested_blocks/nested_blocks.py
+++ b/aibolit/patterns/nested_blocks/nested_blocks.py
@@ -22,7 +22,7 @@
 
 import javalang
 from typing import List, Callable, Optional, Any
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 
 class BlockType:
@@ -86,7 +86,7 @@ class NestedBlocks:
 
     def value(self, filename: str) -> List[int]:
         '''Return line numbers in the file where patterns are found'''
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
         for_links = []
         self.__for_node_depth(
             tree,

--- a/aibolit/patterns/nested_blocks/nested_blocks.py
+++ b/aibolit/patterns/nested_blocks/nested_blocks.py
@@ -22,6 +22,7 @@
 
 import javalang
 from typing import List, Callable, Optional, Any
+from aibolit.utils.ast import Ast
 
 
 class BlockType:
@@ -38,13 +39,6 @@ class NestedBlocks:
     def __init__(self, max_depth: int, block_type=BlockType.FOR):
         self.max_depth = max_depth
         self.block_type = block_type
-
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        '''Takes path to java class file and returns AST Tree'''
-        with open(filename, encoding='utf-8') as file:
-            tree = javalang.parse.parse(file.read())
-
-        return tree
 
     def __for_node_depth(
         self,
@@ -92,7 +86,7 @@ class NestedBlocks:
 
     def value(self, filename: str) -> List[int]:
         '''Return line numbers in the file where patterns are found'''
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
         for_links = []
         self.__for_node_depth(
             tree,

--- a/aibolit/patterns/null_check/null_check.py
+++ b/aibolit/patterns/null_check/null_check.py
@@ -23,7 +23,7 @@
 import javalang.ast
 import javalang.parse
 import javalang.tree
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 
 _OP_EQUALITY = '=='
@@ -32,7 +32,7 @@ _LT_NULL = 'null'
 
 class NullCheck(object):
     def value(self, filename: str):
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
 
         return self.__traverse_node(tree)
 

--- a/aibolit/patterns/null_check/null_check.py
+++ b/aibolit/patterns/null_check/null_check.py
@@ -23,6 +23,7 @@
 import javalang.ast
 import javalang.parse
 import javalang.tree
+from aibolit.utils.ast import Ast
 
 
 _OP_EQUALITY = '=='
@@ -31,19 +32,9 @@ _LT_NULL = 'null'
 
 class NullCheck(object):
     def value(self, filename: str):
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
 
         return self.__traverse_node(tree)
-
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-
-        with open(filename) as file:
-            return javalang.parse.parse(file.read())
 
     def __traverse_node(self, tree: javalang.ast.Node):
         lines = list()

--- a/aibolit/patterns/partial_synchronized/partial_synchronized.py
+++ b/aibolit/patterns/partial_synchronized/partial_synchronized.py
@@ -32,15 +32,6 @@ class PartialSync:
     def __init__(self):
         pass
 
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            tree = javalang.parse.parse(file.read())
-
-        return tree
-
     def value(self, filename):
         # tree = self.__file_to_ast(filename)
         total_code_lines = set()

--- a/aibolit/patterns/redundant_catch/redundant_catch.py
+++ b/aibolit/patterns/redundant_catch/redundant_catch.py
@@ -23,7 +23,7 @@
 import itertools
 import re
 from collections import namedtuple
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 import javalang
 
@@ -36,7 +36,7 @@ class RedundantCatch:
         pass
 
     def value(self, filename):
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
         with open(filename, encoding='utf-8') as file:
             lines_str = file.readlines()
 

--- a/aibolit/patterns/redundant_catch/redundant_catch.py
+++ b/aibolit/patterns/redundant_catch/redundant_catch.py
@@ -23,6 +23,7 @@
 import itertools
 import re
 from collections import namedtuple
+from aibolit.utils.ast import Ast
 
 import javalang
 
@@ -34,17 +35,8 @@ class RedundantCatch:
     def __init__(self):
         pass
 
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            tree = javalang.parse.parse(file.read())
-
-        return tree
-
     def value(self, filename):
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
         with open(filename, encoding='utf-8') as file:
             lines_str = file.readlines()
 

--- a/aibolit/patterns/return_null/return_null.py
+++ b/aibolit/patterns/return_null/return_null.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from collections import defaultdict
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 import javalang
 
@@ -36,7 +36,7 @@ class ReturnNull:
         Travers over AST tree and finds pattern
         :param filename:
         """
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
         chain_lst = defaultdict(int)
         for _, method_node in tree.filter(javalang.tree.MethodDeclaration):
             for _, return_node in method_node.filter(javalang.tree.ReturnStatement):

--- a/aibolit/patterns/return_null/return_null.py
+++ b/aibolit/patterns/return_null/return_null.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 from collections import defaultdict
+from aibolit.utils.ast import Ast
 
 import javalang
 
@@ -30,22 +31,12 @@ class ReturnNull:
     def __init__(self):
         pass
 
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            res = javalang.parse.parse(file.read())
-        return res
-
     def value(self, filename: str):
         """
         Travers over AST tree and finds pattern
         :param filename:
         """
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
         chain_lst = defaultdict(int)
         for _, method_node in tree.filter(javalang.tree.MethodDeclaration):
             for _, return_node in method_node.filter(javalang.tree.ReturnStatement):

--- a/aibolit/patterns/string_concat/string_concat.py
+++ b/aibolit/patterns/string_concat/string_concat.py
@@ -10,8 +10,8 @@ class StringConcatFinder:
 
     """
         @todo #131:30min NoComments implementation of Ast
-         this __file_to_ast implementation differs from usual ones since it 
-         removes the comments from it. Implement a decorator to Ast which does 
+         this __file_to_ast implementation differs from usual ones since it
+         removes the comments from it. Implement a decorator to Ast which does
          it and replace it here. Don't forget the tests.
     """
     def __file_to_ast(self, filename: str) -> javalang.ast.Node:

--- a/aibolit/patterns/string_concat/string_concat.py
+++ b/aibolit/patterns/string_concat/string_concat.py
@@ -8,6 +8,12 @@ class StringConcatFinder:
     def __init__(self):
         pass
 
+    """
+        @todo #131:30min NoComments implementation of Ast
+         this __file_to_ast implementation differs from usual ones since it 
+         removes the comments from it. Implement a decorator to Ast which does 
+         it and replace it here. Don't forget the tests.
+    """
     def __file_to_ast(self, filename: str) -> javalang.ast.Node:
         """
         Takes path to java class file and returns AST Tree

--- a/aibolit/patterns/supermethod/supermethod.py
+++ b/aibolit/patterns/supermethod/supermethod.py
@@ -1,20 +1,10 @@
 import javalang
-
+from aibolit.utils.ast import Ast
 
 class SuperMethod:
 
     def __init__(self):
         pass
-
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            res = javalang.parse.parse(file.read())
-        return res
 
     def value(self, filename: str):
         """
@@ -26,7 +16,7 @@ class SuperMethod:
         :return: Lines of code
         """
         results = []
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
         with open(filename, encoding='utf-8') as file:
             text_lines = file.readlines()
         for _, method_decl_node in tree.filter(javalang.tree.MethodDeclaration):

--- a/aibolit/patterns/supermethod/supermethod.py
+++ b/aibolit/patterns/supermethod/supermethod.py
@@ -1,5 +1,5 @@
 import javalang
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 class SuperMethod:
 
@@ -16,7 +16,7 @@ class SuperMethod:
         :return: Lines of code
         """
         results = []
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
         with open(filename, encoding='utf-8') as file:
             text_lines = file.readlines()
         for _, method_decl_node in tree.filter(javalang.tree.MethodDeclaration):

--- a/aibolit/patterns/supermethod/supermethod.py
+++ b/aibolit/patterns/supermethod/supermethod.py
@@ -1,6 +1,7 @@
 import javalang
 from aibolit.utils.ast import AST
 
+
 class SuperMethod:
 
     def __init__(self):

--- a/aibolit/patterns/this_finder/this_finder.py
+++ b/aibolit/patterns/this_finder/this_finder.py
@@ -21,15 +21,10 @@
 # SOFTWARE.
 
 import javalang
+from aibolit.utils.ast import Ast
 
 
 class ThisFinder:
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        '''Takes path to java class file and returns AST Tree'''
-        with open(filename, encoding='utf-8') as file:
-            tree = javalang.parse.parse(file.read())
-
-        return tree
 
     def __expr_stat(self, expr, flag_this, flag_else):
         '''function to work with StatementExpression block'''
@@ -104,7 +99,7 @@ class ThisFinder:
 
     def value(self, filename: str):
         '''main function'''
-        tree = self.__file_to_ast(filename)
+        tree = Ast(filename).value()
         num_str = []
         for path, node in tree.filter(javalang.tree.ConstructorDeclaration):
             number = node.position.line

--- a/aibolit/patterns/this_finder/this_finder.py
+++ b/aibolit/patterns/this_finder/this_finder.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 import javalang
-from aibolit.utils.ast import Ast
+from aibolit.utils.ast import AST
 
 
 class ThisFinder:
@@ -99,7 +99,7 @@ class ThisFinder:
 
     def value(self, filename: str):
         '''main function'''
-        tree = Ast(filename).value()
+        tree = AST(filename).value()
         num_str = []
         for path, node in tree.filter(javalang.tree.ConstructorDeclaration):
             number = node.position.line

--- a/aibolit/patterns/var_decl_diff/var_decl_diff.py
+++ b/aibolit/patterns/var_decl_diff/var_decl_diff.py
@@ -34,13 +34,6 @@ class VarDeclarationDistance:
     def __init__(self, lines_th: int):
         self.__lines_th = lines_th
 
-    def __file_to_ast(self, filename: str) -> javalang.ast.Node:
-        '''Takes path to java class file and returns AST Tree'''
-        with open(filename, encoding='utf-8') as file:
-            tree = javalang.parse.parse(file.read())
-
-        return tree
-
     def __node_name(self, node) -> Optional[str]:
         qualifier = node.qualifier if hasattr(node, 'qualifier') else None
         member = node.member if hasattr(node, 'member') else None

--- a/aibolit/patterns/var_middle/var_middle.py
+++ b/aibolit/patterns/var_middle/var_middle.py
@@ -58,6 +58,7 @@ class ASTNode:
         self.node = node  # javalang AST node object
         self.scope = scope  # ID of scope this node belongs
 
+
 class JavalangImproved:
 
     def __init__(self, filename: str):
@@ -67,8 +68,8 @@ class JavalangImproved:
 
     """
         @todo #131:30min Lines implementation of Ast
-         this __file_to_ast implementation differs from usual one since it 
-         also returns the lines from file. Implement a decorator to Ast which 
+         this __file_to_ast implementation differs from usual one since it
+         also returns the lines from file. Implement a decorator to Ast which
          does it and replace it here. Don't forget the tests.
     """
     def __file_to_ast(self, filename: str) -> javalang.ast.Node:

--- a/aibolit/patterns/var_middle/var_middle.py
+++ b/aibolit/patterns/var_middle/var_middle.py
@@ -58,7 +58,6 @@ class ASTNode:
         self.node = node  # javalang AST node object
         self.scope = scope  # ID of scope this node belongs
 
-
 class JavalangImproved:
 
     def __init__(self, filename: str):
@@ -66,6 +65,12 @@ class JavalangImproved:
         self.tree = tree
         self.lines = lines
 
+    """
+        @todo #131:30min Lines implementation of Ast
+         this __file_to_ast implementation differs from usual one since it 
+         also returns the lines from file. Implement a decorator to Ast which 
+         does it and replace it here. Don't forget the tests.
+    """
     def __file_to_ast(self, filename: str) -> javalang.ast.Node:
         '''Takes path to java class file and returns AST Tree'''
         with open(filename, encoding='utf-8') as file:

--- a/aibolit/utils/ast.py
+++ b/aibolit/utils/ast.py
@@ -1,7 +1,7 @@
 import javalang
 
 
-class Ast:
+class AST:
     """
     Returns the AST for some java file
     """
@@ -10,6 +10,12 @@ class Ast:
         self._filename = filename
 
     def value(self) -> javalang.ast.Node:
+        """
+        @todo #131:30min Introduce tests for AST.value method.
+         Currently AST.value method is not being tested. It justs delegates a
+         call to javalang library, but we should at least test which kinds of
+         file this class should and which it should not support.
+        """
         with open(self._filename, encoding='utf-8') as file:
             tree = javalang.parse.parse(file.read())
         return tree

--- a/aibolit/utils/ast.py
+++ b/aibolit/utils/ast.py
@@ -1,0 +1,15 @@
+import javalang
+
+
+class Ast:
+    """
+    Returns the AST for some java file
+    """
+
+    def __init__(self, filename: str):
+        self._filename = filename
+
+    def value(self) -> javalang.ast.Node:
+        with open(self._filename, encoding='utf-8') as file:
+            tree = javalang.parse.parse(file.read())
+        return tree


### PR DESCRIPTION
For #131:
- Implemented `Ast` class, which represents the Abstract Syntax Tree from some java file
- Removed `__file_to_ast`  from pattern classes
- Left puzzle to implement `Ast` decorators where `__file_to_ast` needs to be extended