### PR TITLE
For #159: removed outdated code and todo

### DIFF
--- a/aibolit/patterns/string_concat/string_concat.py
+++ b/aibolit/patterns/string_concat/string_concat.py
@@ -10,26 +10,6 @@ class StringConcatFinder:
     def __init__(self):
         pass
 
-    """
-        @todo #131:30min NoComments implementation of Ast
-         this __file_to_ast implementation differs from usual ones since it
-         removes the comments from it. Implement a decorator to Ast which does
-         it and replace it here. Don't forget the tests.
-    """
-
-    def __file_to_ast(self, filename: str) -> Tuple[str, Dict[str, int]]:
-        """
-        Takes path to java class file and returns AST Tree
-        :param filename:
-        :return: Tree
-        """
-        with open(filename, encoding='utf-8') as file:
-            text = file.read()
-            lines_map = {line: i for i, line in enumerate(text.splitlines(), start=1)}
-            res = RemoveComments.remove_comments(text)
-
-        return res, lines_map
-
     # flake8: noqa: C901
     def value(self, filename: str) -> List[LineNumber]:
         import javalang


### PR DESCRIPTION
For #159 :  Looks like #159 is outdated, `string_concat` does not uses `__file_to_ast implementation` method anymore. So I think that there's no point in making a NoComments implementation of AST right now, it wouldn't be used anywhere.

Removed the outdated method and the todo.
