### PR TITLE
For #357: non_final_attribute in interfaces

### DIFF
--- a/aibolit/patterns/non_final_attribute/non_final_attribute.py
+++ b/aibolit/patterns/non_final_attribute/non_final_attribute.py
@@ -1,7 +1,7 @@
 
 from typing import List
 
-from javalang.tree import FieldDeclaration
+from javalang.tree import FieldDeclaration, ClassDeclaration
 
 from aibolit.types_decl import LineNumber
 from aibolit.utils.ast_builder import build_ast
@@ -13,6 +13,9 @@ class NonFinalAttribute:
         pass
 
     def value(self, filename: str) -> List[LineNumber]:
-        tree = build_ast(filename).filter(FieldDeclaration)
-
-        return [node.position.line for path, node in tree if 'final' not in node.modifiers]
+        ret = []
+        for _, clazz in build_ast(filename).filter(ClassDeclaration):
+            for _, field in clazz.filter(FieldDeclaration):
+                if 'final' not in field.modifiers:
+                    ret.append(field.position.line)
+        return list(dict.fromkeys(ret))

--- a/test/patterns/non_final_attribute/AttributeInInterface.java
+++ b/test/patterns/non_final_attribute/AttributeInInterface.java
@@ -1,0 +1,5 @@
+package patterns.non_final_attribute;
+
+interface AttributeInInterface {
+    int ATTRIBUTE = 1;
+}

--- a/test/patterns/non_final_attribute/test_non_final_attribute.py
+++ b/test/patterns/non_final_attribute/test_non_final_attribute.py
@@ -15,3 +15,7 @@ class TestNonFinalAttribute(TestCase):
     def test_nested_class(self):
         lines = NonFinalAttribute().value(Path(self.dir_path, 'File.java'))
         self.assertEqual(lines, [12, 16, 64])
+
+    def test_attribute_in_interface(self):
+        lines = NonFinalAttribute().value(Path(self.dir_path, 'AttributeInInterface.java'))
+        self.assertEqual(lines, [])


### PR DESCRIPTION
For #357: 
- changed `non_final_attribute` pattern to ignore non final attributes in interface
- added test to this new condition